### PR TITLE
perf(#37): overlap Firecracker launch with dm-thin snapshot

### DIFF
--- a/docs/plans/2026-03-11-parallel-fc-launch-design.md
+++ b/docs/plans/2026-03-11-parallel-fc-launch-design.md
@@ -1,0 +1,41 @@
+# Parallel Firecracker Launch Design
+
+**Date:** 2026-03-11
+
+**Issue:** #37
+
+**Goal:** Reduce create/fork latency by overlapping dm-thin snapshot creation with Firecracker process startup.
+
+## Problem
+
+`VMManager.create()` and `VMManager.fork_from_checkpoint()` currently do these steps in sequence:
+
+1. create tap
+2. create dm-thin snapshot
+3. start Firecracker process
+4. configure and boot
+5. wait for SSH
+
+The dm-thin snapshot and Firecracker process startup are independent until `configure_and_boot()` needs the rootfs path to exist. Running them sequentially leaves a small but free latency win on the table.
+
+## Chosen approach
+
+Add one small helper in `src/mshkn/vm/manager.py` that:
+
+1. starts `create_snapshot(...)` in an `asyncio.Task`
+2. starts Firecracker immediately
+3. waits for the snapshot to finish before calling `configure_and_boot(...)`
+
+Both `create()` and `fork_from_checkpoint()` will use this helper so the overlap and cleanup logic is shared.
+
+## Error handling
+
+- If Firecracker process startup fails, cancel and await the snapshot task, then re-raise.
+- If snapshot creation fails after Firecracker has started, kill the Firecracker process, then re-raise.
+- Existing ordering for tap creation, SSH readiness, DB writes, and Caddy route registration stays unchanged.
+
+## Testing
+
+Add a focused unit test which proves `start_firecracker_process()` is invoked before the snapshot task completes. This verifies the overlap directly without relying on noisy wall-clock latency assertions.
+
+Run targeted tests first, then broader non-E2E verification.

--- a/docs/plans/2026-03-11-parallel-fc-launch-plan.md
+++ b/docs/plans/2026-03-11-parallel-fc-launch-plan.md
@@ -1,0 +1,106 @@
+# Parallel Firecracker Launch Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Overlap dm-thin snapshot creation with Firecracker process startup in VM create/fork paths.
+
+**Architecture:** Add one helper in `VMManager` that owns the shared overlap behavior and cleanup. Update both `create()` and `fork_from_checkpoint()` to use it, then add a focused regression test proving the snapshot and process-start steps are actually overlapped.
+
+**Tech Stack:** Python 3.12, asyncio, pytest, Firecracker, dm-thin
+
+---
+
+### Task 1: Add a failing regression test for overlapped startup
+
+**Files:**
+- Modify: `tests/test_vm_manager.py`
+- Modify: `src/mshkn/vm/manager.py`
+
+**Step 1: Write the failing test**
+
+Add a unit test that:
+- patches `create_snapshot()` to block on an `asyncio.Event`
+- patches `start_firecracker_process()` to record that it was called
+- invokes the shared startup helper or the smallest reachable manager path
+- asserts Firecracker start is reached before the snapshot is released
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_vm_manager.py -k parallel -v`
+
+Expected: FAIL because the helper does not yet exist or the call order is still sequential.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_vm_manager.py
+git commit -m "test: cover parallel snapshot and firecracker startup"
+```
+
+### Task 2: Implement shared overlap helper in VMManager
+
+**Files:**
+- Modify: `src/mshkn/vm/manager.py`
+
+**Step 1: Write minimal implementation**
+
+Add a helper which:
+- creates the snapshot task
+- starts Firecracker
+- awaits the snapshot before returning the pid
+- cancels the snapshot task if Firecracker startup fails
+- kills Firecracker if the snapshot task fails after startup
+
+Use the helper from both `create()` and `fork_from_checkpoint()`.
+
+**Step 2: Run the targeted test**
+
+Run: `.venv/bin/pytest tests/test_vm_manager.py -k parallel -v`
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/mshkn/vm/manager.py tests/test_vm_manager.py
+git commit -m "perf: overlap dm-thin snapshot with firecracker startup"
+```
+
+### Task 3: Verify no regressions in local non-E2E coverage
+
+**Files:**
+- Modify: none unless failures require targeted fixes
+
+**Step 1: Run relevant local tests**
+
+Run: `.venv/bin/pytest tests/test_vm_manager.py tests/test_checkpoint_parent.py -v`
+
+Expected: PASS
+
+**Step 2: Run broader local validation**
+
+Run: `.venv/bin/pytest tests/ --ignore=tests/e2e --ignore=tests/integration -x`
+
+Expected: PASS
+
+### Task 4: Verify live latency path
+
+**Files:**
+- Modify: none unless live verification reveals a regression
+
+**Step 1: Deploy branch**
+
+Run the normal deploy workflow for the branch.
+
+**Step 2: Run targeted live latency tests**
+
+Run: `MSHKN_API_URL=http://135.181.6.215:8000 .venv/bin/pytest tests/e2e/test_phase1_latency.py -v --tb=short`
+
+Expected: PASS with no latency regression and ideally measurable create/fork improvement.
+
+**Step 3: Commit only if follow-up fixes were required**
+
+```bash
+git add <files>
+git commit -m "fix: address verification regressions for parallel launch"
+```

--- a/src/mshkn/vm/manager.py
+++ b/src/mshkn/vm/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
@@ -184,6 +185,38 @@ class VMManager:
         self._next_volume_id += 1
         return vol_id
 
+    async def _start_firecracker_with_snapshot(
+        self,
+        source_volume_id: int,
+        volume_id: int,
+        volume_name: str,
+        socket_path: str,
+    ) -> int:
+        snapshot_task = asyncio.create_task(
+            create_snapshot(
+                pool_name=self.config.thin_pool_name,
+                source_volume_id=source_volume_id,
+                new_volume_id=volume_id,
+                new_volume_name=volume_name,
+                sectors=self.config.thin_volume_sectors,
+            )
+        )
+        try:
+            pid = await start_firecracker_process(socket_path)
+        except Exception:
+            snapshot_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await snapshot_task
+            raise
+
+        try:
+            await snapshot_task
+        except Exception:
+            await kill_firecracker_process(pid)
+            raise
+
+        return pid
+
     async def _get_or_build_capability_volume(self, manifest: Manifest) -> int:
         """Return the volume_id of a capability base volume for this manifest.
 
@@ -276,17 +309,13 @@ class VMManager:
         # 1. Create tap device
         await create_tap(slot)
 
-        # 2. Create dm-thin snapshot from capability base
-        await create_snapshot(
-            pool_name=self.config.thin_pool_name,
+        # 2-3. Create dm-thin snapshot and start Firecracker in parallel
+        pid = await self._start_firecracker_with_snapshot(
             source_volume_id=source_volume_id,
-            new_volume_id=volume_id,
-            new_volume_name=volume_name,
-            sectors=self.config.thin_volume_sectors,
+            volume_id=volume_id,
+            volume_name=volume_name,
+            socket_path=socket_path,
         )
-
-        # 3. Start Firecracker
-        pid = await start_firecracker_process(socket_path)
 
         # 4. Configure and boot
         fc_client = FirecrackerClient(socket_path)
@@ -386,17 +415,13 @@ class VMManager:
         # 1. Create tap device
         await create_tap(slot)
 
-        # 2. Create dm-thin snapshot from the checkpoint's frozen disk (O(1) CoW)
-        await create_snapshot(
-            pool_name=self.config.thin_pool_name,
+        # 2-3. Create checkpoint disk snapshot and start Firecracker in parallel
+        pid = await self._start_firecracker_with_snapshot(
             source_volume_id=checkpoint.thin_volume_id,
-            new_volume_id=volume_id,
-            new_volume_name=volume_name,
-            sectors=self.config.thin_volume_sectors,
+            volume_id=volume_id,
+            volume_name=volume_name,
+            socket_path=socket_path,
         )
-
-        # 3. Start Firecracker and cold-boot from the snapshot disk
-        pid = await start_firecracker_process(socket_path)
         fc_client = FirecrackerClient(socket_path)
         try:
             await fc_client.configure_and_boot(

--- a/tests/test_vm_manager.py
+++ b/tests/test_vm_manager.py
@@ -1,6 +1,9 @@
 import asyncio
 
+import pytest
+
 from mshkn.config import Config
+from mshkn.vm import manager as vm_manager_module
 from mshkn.vm.manager import VMManager
 
 
@@ -27,3 +30,65 @@ def test_slot_allocation() -> None:
     manager._release_slot(1)
     assert manager._allocate_slot() == 1  # reuses freed slot
     assert manager._allocate_slot() == 3  # next new slot
+
+
+@pytest.mark.asyncio
+async def test_start_firecracker_with_snapshot_overlaps_snapshot_and_process_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = VMManager.__new__(VMManager)
+    manager.config = Config()
+
+    order: list[str] = []
+    release_snapshot = asyncio.Event()
+
+    async def fake_create_snapshot(
+        pool_name: str,
+        source_volume_id: int,
+        new_volume_id: int,
+        new_volume_name: str,
+        sectors: int,
+    ) -> None:
+        _ = (pool_name, source_volume_id, new_volume_id, new_volume_name, sectors)
+        order.append("snapshot-start")
+        await release_snapshot.wait()
+        order.append("snapshot-done")
+
+    async def fake_start_firecracker_process(socket_path: str) -> int:
+        _ = socket_path
+        order.append("firecracker-start")
+        return 123
+
+    async def fake_kill_firecracker_process(pid: int) -> None:
+        order.append(f"kill-{pid}")
+
+    monkeypatch.setattr(vm_manager_module, "create_snapshot", fake_create_snapshot)
+    monkeypatch.setattr(
+        vm_manager_module,
+        "start_firecracker_process",
+        fake_start_firecracker_process,
+    )
+    monkeypatch.setattr(
+        vm_manager_module,
+        "kill_firecracker_process",
+        fake_kill_firecracker_process,
+    )
+
+    task = asyncio.create_task(
+        manager._start_firecracker_with_snapshot(
+            source_volume_id=10,
+            volume_id=20,
+            volume_name="mshkn-comp-test",
+            socket_path="/tmp/fc-test.socket",
+        )
+    )
+
+    await asyncio.sleep(0)
+    assert "firecracker-start" in order
+    assert "snapshot-done" not in order
+
+    release_snapshot.set()
+    pid = await task
+    assert pid == 123
+    assert "snapshot-start" in order
+    assert order.index("firecracker-start") < order.index("snapshot-done")


### PR DESCRIPTION
Closes #37

## What this does

This change overlaps two independent steps in both VM create paths:

- dm-thin snapshot creation
- Firecracker process startup

`VMManager.create()` and `VMManager.fork_from_checkpoint()` previously did those sequentially before `configure_and_boot()`. The new shared helper starts `create_snapshot(...)` in an `asyncio.Task`, starts Firecracker immediately, then waits for the snapshot before configuring the VM. That removes a small but free chunk of startup latency from both create and fork.

## Implementation

- adds `_start_firecracker_with_snapshot()` in `src/mshkn/vm/manager.py`
- reuses that helper from `create()` and `fork_from_checkpoint()` to avoid duplicated overlap and cleanup logic
- cancels the snapshot task if Firecracker startup fails
- kills the Firecracker process if snapshot creation fails after startup

## Docs included

This PR also includes the design and execution notes used for the change:

- `docs/plans/2026-03-11-parallel-fc-launch-design.md`
- `docs/plans/2026-03-11-parallel-fc-launch-plan.md`

## Verification

Outside the sandbox:

- `timeout 60 .venv/bin/pytest tests/test_vm_manager.py -v`
- `timeout 60 .venv/bin/pytest tests/test_checkpoint_parent.py tests/test_checkpoint_label_filter.py tests/test_exclusive_restore.py -v`

Results:

- `tests/test_vm_manager.py`: `2 passed`
- checkpoint-related slice: `16 passed`

I also added a focused regression test proving Firecracker startup is reached before snapshot completion, which directly verifies the new overlap behavior.
